### PR TITLE
Use protocol independent tile url on swiss dialect map

### DIFF
--- a/lang/index.html
+++ b/lang/index.html
@@ -15,28 +15,28 @@
 
 		var map = L.map('map').setView([47, 8], 8);
 
-		var gsw = L.tileLayer('http://tile.osm.ch/name-gsw/{z}/{x}/{y}.png', {
+		var gsw = L.tileLayer('//tile.osm.ch/name-gsw/{z}/{x}/{y}.png', {
 			maxZoom: 18,
           		attribution: 'data &copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors, ' +
             'map <a href="https://creativecommons.org/licenses/by/4.0/">cc-by</a> ' +
             '<a href="https://github.com/xyztobixyz/OSM-Swiss-Style">xyztobixyz</a>',
 		});
 
-		var rm = L.tileLayer('http://tile.osm.ch/name-rm/{z}/{x}/{y}.png', {
+		var rm = L.tileLayer('//tile.osm.ch/name-rm/{z}/{x}/{y}.png', {
 			maxZoom: 18,
           		attribution: 'data &copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors, ' +
             'map <a href="https://creativecommons.org/licenses/by/4.0/">cc-by</a> ' +
             '<a href="https://github.com/xyztobixyz/OSM-Swiss-Style">xyztobixyz</a>',
 		});
 
-		var it = L.tileLayer('http://tile.osm.ch/name-it/{z}/{x}/{y}.png', {
+		var it = L.tileLayer('//tile.osm.ch/name-it/{z}/{x}/{y}.png', {
 			maxZoom: 18,
           		attribution: 'data &copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors, ' +
             'map <a href="https://creativecommons.org/licenses/by/4.0/">cc-by</a> ' +
             '<a href="https://github.com/xyztobixyz/OSM-Swiss-Style">xyztobixyz</a>',
 		});
 
-		var fr = L.tileLayer('http://tile.osm.ch/name-fr/{z}/{x}/{y}.png', {
+		var fr = L.tileLayer('//tile.osm.ch/name-fr/{z}/{x}/{y}.png', {
 			maxZoom: 18,
           		attribution: 'data &copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors, ' +
             'map <a href="https://creativecommons.org/licenses/by/4.0/">cc-by</a> ' +


### PR DESCRIPTION
To avoid mixed content warnings when loading tiles on our swiss dialect map, I propose to use the protocol independent url without http: at the beginning. We already use that on the chlv95.html page.