### PR TITLE
use min-height for .header

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -12,7 +12,7 @@ body{
 }
 .header{
     background-color: white;
-    height: 25vh;
+    min-height: 25vh;
 }
 .header > div{
     width: 100%;


### PR DESCRIPTION
Avoids main text merging into the header when the font is quite large.

Current site for me:

![osm-ch-before](https://user-images.githubusercontent.com/1447941/192477544-c0c8e96d-d139-4afd-8410-13d7f6547cfb.jpg)

After the change:

![osm-ch-after](https://user-images.githubusercontent.com/1447941/192477605-c9ed2fad-b8d2-49f2-8c41-065222c1a83e.jpg)
