### PR TITLE
Add link to join IRC via Matrix bridge

### DIFF
--- a/hilfe.html
+++ b/hilfe.html
@@ -92,8 +92,11 @@
                     Chat-Programm nutzen (Server
                     <a target="_blank" href="https://www.oftc.net">
                         irc.oftc.net</a>,
-                    Channel #osm-ch), oder den Web-Client direkt im Browser verwenden
-                    (<a target="_blank" href="https://webchat.oftc.net/?channels=osm-ch">webchat.oftc.net/?channels=osm-ch</a>).
+                    Channel #osm-ch), den Web-Client direkt im Browser verwenden
+                    (<a target="_blank" href="https://webchat.oftc.net/?channels=osm-ch">webchat.oftc.net/?channels=osm-ch</a>)
+                    oder per <a target="_blank" href="https://matrix.org/">Matrix</a> mit einem
+                    <a target="_blank" href="https://matrix.org/ecosystem/clients/">Matrix-Client</a>
+                    <a target="_blank" href="https://matrix.to/#/#_oftc_#osm-ch:matrix.org">über eine Brücke beitreten</a>.
                 </p>
                 <h3>Forum</h3>
                 <p>


### PR DESCRIPTION
This seems to be used by many these days, but finding the right room tends to be a bit tricky, so it seems useful to document this on the website.