### PR TITLE
replace all http links with https if the target supports that

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -81,7 +81,7 @@
                     <a href="https://creativecommons.org/licenses/by-sa/4.0/">cc-by-sa 4.0</a>
                     Lizenz veröffentlicht. Autoren sind Flavio Piagno, Claudia Löckher
             </div>
-            <div class="footer"><a href="contact.html">Operated by SOSM, Contact/Imprint</a> <a href="http://sosm.ch/about/terms-of-service/">Nutzungsbedingungen und Datenschutz.</a> Hosting sponsored by <a href="https://adfinis.com">Adfinis</a> and <a href="https://www.init7.net/?utm_source=osm&utm_campaign=sponsoring">Init7</a></div>
+            <div class="footer"><a href="contact.html">Operated by SOSM, Contact/Imprint</a> <a href="https://sosm.ch/about/terms-of-service/">Nutzungsbedingungen und Datenschutz.</a> Hosting sponsored by <a href="https://adfinis.com">Adfinis</a> and <a href="https://www.init7.net/?utm_source=osm&utm_campaign=sponsoring">Init7</a></div>
         </div>
     </body>
 </html>

--- a/entwickler.html
+++ b/entwickler.html
@@ -105,7 +105,7 @@
                     Erstellen einer Webkarte mit POIs. Und das alles, ohne einen eigenen Webserver zu benötigen.
                 </p>
             </div>
-            <div class="footer"><a href="contact.html">Operated by SOSM, Contact/Imprint</a> <a href="http://sosm.ch/about/terms-of-service/">Nutzungsbedingungen und Datenschutz.</a> Hosting sponsored by <a href="https://adfinis.com">Adfinis</a> and <a href="https://www.init7.net/?utm_source=osm&utm_campaign=sponsoring">Init7</a></div>
+            <div class="footer"><a href="contact.html">Operated by SOSM, Contact/Imprint</a> <a href="https://sosm.ch/about/terms-of-service/">Nutzungsbedingungen und Datenschutz.</a> Hosting sponsored by <a href="https://adfinis.com">Adfinis</a> and <a href="https://www.init7.net/?utm_source=osm&utm_campaign=sponsoring">Init7</a></div>
         </div>
     </body>
 </html>

--- a/hilfe.html
+++ b/hilfe.html
@@ -125,7 +125,7 @@
                         OpenStreetMap-Kalender (osmcal)</a>.
                 </p>
             </div>
-            <div class="footer"><a href="contact.html">Operated by SOSM, Contact/Imprint</a> <a href="http://sosm.ch/about/terms-of-service/">Nutzungsbedingungen und Datenschutz.</a> Hosting sponsored by <a href="https://adfinis.com">Adfinis</a> and <a href="https://www.init7.net/?utm_source=osm&utm_campaign=sponsoring">Init7</a></div>
+            <div class="footer"><a href="contact.html">Operated by SOSM, Contact/Imprint</a> <a href="https://sosm.ch/about/terms-of-service/">Nutzungsbedingungen und Datenschutz.</a> Hosting sponsored by <a href="https://adfinis.com">Adfinis</a> and <a href="https://www.init7.net/?utm_source=osm&utm_campaign=sponsoring">Init7</a></div>
         </div>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
                     <a class="ie-developer" href="entwickler.html"><h1>Für Entwickler</h1></a>
                 </div>
             </div>
-            <div class="footer"><a href="contact.html">Operated by SOSM, Contact/Imprint</a> <a href="http://sosm.ch/about/terms-of-service/">Nutzungsbedingungen und Datenschutz.</a> Hosting sponsored by <a href="https://adfinis.com">Adfinis</a> and <a href="https://www.init7.net/?utm_source=osm&utm_campaign=sponsoring">Init7</a></div>
+            <div class="footer"><a href="contact.html">Operated by SOSM, Contact/Imprint</a> <a href="https://sosm.ch/about/terms-of-service/">Nutzungsbedingungen und Datenschutz.</a> Hosting sponsored by <a href="https://adfinis.com">Adfinis</a> and <a href="https://www.init7.net/?utm_source=osm&utm_campaign=sponsoring">Init7</a></div>
         </div>
     </body>
 </html>

--- a/nutze-osm.html
+++ b/nutze-osm.html
@@ -60,7 +60,7 @@
                 <p>
                     SOSM betreibt einen eigenen Dienst zum Rendering
                     von Karten. Im Angebot stehen der Stil von
-                    <a target="_blank" href="http://wiki.openstreetmap.org/">
+                    <a target="_blank" href="https://wiki.openstreetmap.org/">
 	                  openstreetmap.org</a>,
                     leicht angepasst auf Schweizer Bedürfnisse, und
                     ein reduzierter Stil, welcher
@@ -75,7 +75,7 @@
                 <p>
                     <ul>
                         <li>
-                                <a target="_blank" href="http://waymarkedtrails.org">
+                                <a target="_blank" href="https://waymarkedtrails.org">
                                     waymarkedtrails.org</a>
                                 stellt ausgeschilderte Wege dar, wie zum Beispiel
                                 Wanderwege, Velowege oder Skipisten.
@@ -119,7 +119,7 @@
                     zur Verfügung.
                 </p>
             </div>
-            <div class="footer"><a href="contact.html">Operated by SOSM, Contact/Imprint</a> <a href="http://sosm.ch/about/terms-of-service/">Nutzungsbedingungen und Datenschutz.</a> Hosting sponsored by <a href="https://adfinis.com">Adfinis</a> and <a href="https://www.init7.net/?utm_source=osm&utm_campaign=sponsoring">Init7</a></div>
+            <div class="footer"><a href="contact.html">Operated by SOSM, Contact/Imprint</a> <a href="https://sosm.ch/about/terms-of-service/">Nutzungsbedingungen und Datenschutz.</a> Hosting sponsored by <a href="https://adfinis.com">Adfinis</a> and <a href="https://www.init7.net/?utm_source=osm&utm_campaign=sponsoring">Init7</a></div>
         </div>
     </body>
 </html>

--- a/osm.html
+++ b/osm.html
@@ -86,11 +86,11 @@
                     und direkt die ganze Karte bearbeiten.
                 </p>
                 <h3>
-                    <a target="_blank" href="http://wiki.openstreetmap.org/">Wiki</a>
+                    <a target="_blank" href="https://wiki.openstreetmap.org/">Wiki</a>
                 </h3>
                 <p>
                     Im
-                    <a target="_blank" href="http://wiki.openstreetmap.org/">
+                    <a target="_blank" href="https://wiki.openstreetmap.org/">
                         Wiki</a>
                     findet man Informationen rund um OSM. Zum Beispiel wie einzelne
                     Objekte gemappt werden, oder mit welcher Software man OSM-Daten
@@ -99,7 +99,7 @@
                 <h3>Swiss OpenStreetMap Association, SOSM</h3>
                 <p>
                     ... ist der
-                    <a target="_blank" href="http://sosm.ch">
+                    <a target="_blank" href="https://sosm.ch">
                         Schweizer OpenStreetMap Verein</a>,
                     der auch diese Seite hier betreibt. Er unterstützt und
                     fördert Projekte, Personen, Unternehmungen und Organisationen in
@@ -108,7 +108,7 @@
                     verschiedene Dienste angeboten.
                 </p>
             </div>
-            <div class="footer"><a href="contact.html">Operated by SOSM, Contact/Imprint</a> <a href="http://sosm.ch/about/terms-of-service/">Nutzungsbedingungen und Datenschutz.</a> Hosting sponsored by <a href="https://adfinis.com">Adfinis</a> and <a href="https://www.init7.net/?utm_source=osm&utm_campaign=sponsoring">Init7</a></div>
+            <div class="footer"><a href="contact.html">Operated by SOSM, Contact/Imprint</a> <a href="https://sosm.ch/about/terms-of-service/">Nutzungsbedingungen und Datenschutz.</a> Hosting sponsored by <a href="https://adfinis.com">Adfinis</a> and <a href="https://www.init7.net/?utm_source=osm&utm_campaign=sponsoring">Init7</a></div>
         </div>
     </body>
 </html>

--- a/projekte.html
+++ b/projekte.html
@@ -92,7 +92,7 @@
                     Karten abzeichnen.
                 </p>
             </div>
-            <div class="footer"><a href="contact.html">Operated by SOSM, Contact/Imprint</a> <a href="http://sosm.ch/about/terms-of-service/">Nutzungsbedingungen und Datenschutz.</a> Hosting sponsored by <a href="https://adfinis.com">Adfinis</a> and <a href="https://www.init7.net/?utm_source=osm&utm_campaign=sponsoring">Init7</a></div>
+            <div class="footer"><a href="contact.html">Operated by SOSM, Contact/Imprint</a> <a href="https://sosm.ch/about/terms-of-service/">Nutzungsbedingungen und Datenschutz.</a> Hosting sponsored by <a href="https://adfinis.com">Adfinis</a> and <a href="https://www.init7.net/?utm_source=osm&utm_campaign=sponsoring">Init7</a></div>
         </div>
     </body>
 </html>

--- a/verbessern.html
+++ b/verbessern.html
@@ -63,32 +63,32 @@
                 <p>
                     <ul>
                         <li>
-                                Sind an deiner <a href="http://wiki.osm.org/wiki/DE:Highways">Strasse</a>
-                                schon alle <a href="http://wiki.osm.org/wiki/DE:Key:addr">Hausnummern</a>
+                                Sind an deiner <a href="https://wiki.osm.org/wiki/DE:Highways">Strasse</a>
+                                schon alle <a href="https://wiki.osm.org/wiki/DE:Key:addr">Hausnummern</a>
                                 eingetragen? Und stimmen sie auch?
                         </li>
                         <li>
                                 Sind deine
-                                <a href="http://wiki.osm.org/wiki/DE:Tag:amenity%3Drestaurant">Lieblings-Restaurants</a>
+                                <a href="https://wiki.osm.org/wiki/DE:Tag:amenity%3Drestaurant">Lieblings-Restaurants</a>
                                 eingetragen? Falls ja, vielleicht fehlen da
-                                noch die <a href="http://wiki.osm.org/wiki/DE:Key:opening_hours">Öffnungszeiten</a>,
-                                die <a href="http://wiki.osm.org/wiki/DE:Key:website">Website</a>
-                                oder die <a href="http://wiki.osm.org/wiki/DE:Key:contact">Telefonnummer</a>?
+                                noch die <a href="https://wiki.osm.org/wiki/DE:Key:opening_hours">Öffnungszeiten</a>,
+                                die <a href="https://wiki.osm.org/wiki/DE:Key:website">Website</a>
+                                oder die <a href="https://wiki.osm.org/wiki/DE:Key:contact">Telefonnummer</a>?
                         </li>
                         <li>
-                                Sind die <a href="http://wiki.osm.org/wiki/DE:Key:shop">Läden</a> in deiner
+                                Sind die <a href="https://wiki.osm.org/wiki/DE:Key:shop">Läden</a> in deiner
                                 Umgebung schon eingetragen? Auch dort können Öffnungszeiten, die
                                 Website oder die Telefonnummer (falls vorhanden) eingetragen werden.
-                                Dasselbe gilt für <a href="http://wiki.osm.org/wiki/DE:Key:craft">Handwerker
+                                Dasselbe gilt für <a href="https://wiki.osm.org/wiki/DE:Key:craft">Handwerker
                                 wie Schreiner und Bodenleger</a>, oder
-                                <a href="http://wiki.osm.org/wiki/DE:Tag:amenity%3Ddoctors">Ärzte</a>.
+                                <a href="https://wiki.osm.org/wiki/DE:Tag:amenity%3Ddoctors">Ärzte</a>.
                         </li>
                         <li>
                                 Ist die Infrastruktur deiner Gemeinde erfasst? Zum Beispiel
-                                <a href="http://wiki.osm.org/wiki/DE:Tag:amenity%3Dschool">Schule</a>,
-                                <a href="http://wiki.osm.org/wiki/DE:Tag:amenity%3Dkindergarten">Kinderkrippen</a>,
-                                <a href="http://wiki.osm.org/wiki/DE:Tag:amenity%3Dlibrary">Bibliothek</a> und
-                                <a href="http://wiki.osm.org/wiki/DE:Schwimmbad">Schwimmbad</a>.
+                                <a href="https://wiki.osm.org/wiki/DE:Tag:amenity%3Dschool">Schule</a>,
+                                <a href="https://wiki.osm.org/wiki/DE:Tag:amenity%3Dkindergarten">Kinderkrippen</a>,
+                                <a href="https://wiki.osm.org/wiki/DE:Tag:amenity%3Dlibrary">Bibliothek</a> und
+                                <a href="https://wiki.osm.org/wiki/DE:Schwimmbad">Schwimmbad</a>.
                         </li>
                     </ul>
                 </p>
@@ -96,10 +96,10 @@
                 <p>
                     Die Karte lässt sich mit verschiedenen Editoren bearbeiten. Für den
                     Einstieg eignet sich der einfach zu bedienende und Browser-basierte
-                    <a href="http://wiki.osm.org/wiki/DE:ID">iD-Editor</a>, welcher auf der
+                    <a href="https://wiki.osm.org/wiki/DE:ID">iD-Editor</a>, welcher auf der
                     <a href="https://openstreetmap.org">OSM-Hauptseite</a> beim Klick auf
                     "Bearbeiten" geöffnet wird. Viele fortgeschrittene Benutzer verwenden
-                    <a href="http://wiki.osm.org/wiki/DE:JOSM">JOSM</a>, welcher sehr
+                    <a href="https://wiki.osm.org/wiki/DE:JOSM">JOSM</a>, welcher sehr
                     viele Funktionen und Plugins bietet. Für den mobilen Einsatz auf
                     Android-Geräten gibt es
                     <a href="https://wiki.openstreetmap.org/wiki/DE:Vespucci">Vespucci</a>.
@@ -125,7 +125,7 @@
                     <a href="https://sosm.ch/">SOSM.ch</a>.
                 </p>
 	    </div>
-            <div class="footer"><a href="contact.html">Operated by SOSM, Contact/Imprint</a> <a href="http://sosm.ch/about/terms-of-service/">Nutzungsbedingungen und Datenschutz.</a> Hosting sponsored by <a href="https://adfinis.com">Adfinis</a> and <a href="https://www.init7.net/?utm_source=osm&utm_campaign=sponsoring">Init7</a></div>
+            <div class="footer"><a href="contact.html">Operated by SOSM, Contact/Imprint</a> <a href="https://sosm.ch/about/terms-of-service/">Nutzungsbedingungen und Datenschutz.</a> Hosting sponsored by <a href="https://adfinis.com">Adfinis</a> and <a href="https://www.init7.net/?utm_source=osm&utm_campaign=sponsoring">Init7</a></div>
         </div>
     </body>
 </html>


### PR DESCRIPTION
Normalisation of external links. Previously, some were http and others https, now all those that correctly support https are https.

This means that fewer insecure redirects are necessary and the pages load faster.