### PR TITLE
fix language picker and map layer overlapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,12 +55,14 @@
 				  maphash = new L.Hash(map);
 				}
 				map.invalidateSize();
+				document.getElementById('tx-live-lang-container').style.display = 'none'
 			}
 			function closeMap(){
 				document.getElementById('menu').style.display = 'block';
 				history.pushState("", document.title, window.location.pathname)
 				maphash.stopListening();
 				map.invalidateSize();
+				document.getElementById('tx-live-lang-container').style.display = ''
 			}
 		</script>
         <script type="text/javascript">


### PR DESCRIPTION
In pull request #20 I added the transifex language picker.

Unfortunately, this overlaps the layer selection on the map view.

![osm_ch_lang_overlay](https://github.com/user-attachments/assets/c27684c8-7d6f-46b7-b822-47d5dcdf96c9)

Because the language selection in the map view is useless anyway, I suggest we simply hide transifex when the map is in focus.

